### PR TITLE
Fix deprecation warning 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ It works with ANY class, however, you get a few extra features when you're using
 Add attr_encrypted to your gemfile:
 
 ```ruby
-  gem "attr_encrypted", "~> 3.0.0"
+  gem 'attr_encrypted',
+    git: "#{org_url}/attr_encrypted",
+    tag: '4.0.0'
 ```
 
 Then install the gem:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # attr_encrypted
-[![Build Status](https://secure.travis-ci.org/attr-encrypted/attr_encrypted.svg)](https://travis-ci.org/attr-encrypted/attr_encrypted) [![Test Coverage](https://codeclimate.com/github/attr-encrypted/attr_encrypted/badges/coverage.svg)](https://codeclimate.com/github/attr-encrypted/attr_encrypted/coverage) [![Code Climate](https://codeclimate.com/github/attr-encrypted/attr_encrypted/badges/gpa.svg)](https://codeclimate.com/github/attr-encrypted/attr_encrypted) [![Gem Version](https://badge.fury.io/rb/attr_encrypted.svg)](https://badge.fury.io/rb/attr_encrypted) [![security](https://hakiri.io/github/attr-encrypted/attr_encrypted/master.svg)](https://hakiri.io/github/attr-encrypted/attr_encrypted/master)
+## WARNING!
+This fork is taken from 3.1.0 (tag) version of the original Repo. We have forked this to fix deprecation warnings as
+original gem is not actively maintained now. The master branch has the fix but it has many more updates without
+any official release. In order to avoid any unwanted issues, we are forking from 3.1.0 we were using and fixing on top of this.
 
+We plan to remove this gem when we move to Rails 7 as it would have field encryption option out of the box
+
+## Description
 Generates attr_accessors that transparently encrypt and decrypt attributes.
 
 It works with ANY class, however, you get a few extra features when you're using it with `ActiveRecord`, `DataMapper`, or `Sequel`.

--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -60,7 +60,7 @@ if defined?(ActiveRecord::Base)
 
             if ::ActiveRecord::VERSION::STRING >= "4.1"
               define_method("#{attr}_changed?") do |options = {}|
-                attribute_changed?(attr, options)
+                attribute_changed?(attr, **options)
               end
             else
               define_method("#{attr}_changed?") do

--- a/lib/attr_encrypted/version.rb
+++ b/lib/attr_encrypted/version.rb
@@ -1,8 +1,8 @@
 module AttrEncrypted
   # Contains information about this gem's version
   module Version
-    MAJOR = 3
-    MINOR = 1
+    MAJOR = 4
+    MINOR = 0
     PATCH = 0
 
     # Returns a version string by joining <tt>MAJOR</tt>, <tt>MINOR</tt>, and <tt>PATCH</tt> with <tt>'.'</tt>


### PR DESCRIPTION
Fixes: `ruby/gems/2.7.0/gems/attr_encrypted-3.1.0/lib/attr_encrypted/adapters/active_record.rb:63: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call`